### PR TITLE
Export Title and Namespace object with multiple convenience methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,149 @@ Mediawiki title normalizetion, that conforms to the normalization rules used in 
 In general, the page title is converted to the mediawiki DB key format by trimming spaces, replacing whitespace symbols to underscores
 and applying wiki-specific capitalizetion rules. The namespace name is converted to a localized canonical name.
 
-## Functions
+## Classes
 
 <dl>
-<dt><a href="#normalize">normalize(title, siteInfo)</a> ⇒ <code>string</code></dt>
-<dd><p>Normalize a title according to the rules of <domain></p>
-</dd>
+<dt><a href="#Namespace">Namespace</a></dt>
+<dd></dd>
+<dt><a href="#Title">Title</a></dt>
+<dd></dd>
 </dl>
 
 ## Typedefs
 
 <dl>
 <dt><a href="#SiteInfo">SiteInfo</a> : <code>Object</code></dt>
-<dd><p>Information about a wikimedia site required to make correct normalization.</p>
+<dd><p>Information about a wikimedia site required to make correct
+normalization.</p>
 </dd>
 </dl>
 
-<a name="normalize"></a>
-## normalize(title, siteInfo) ⇒ <code>string</code>
+<a name="Namespace"></a>
+## Namespace
+**Kind**: global class  
+
+* [Namespace](#Namespace)
+    * [new Namespace(id, siteInfo)](#new_Namespace_new)
+    * _instance_
+        * [.isSpecial()](#Namespace+isSpecial) ⇒ <code>boolean</code>
+        * [.isMain()](#Namespace+isMain) ⇒ <code>boolean</code>
+        * [.isTalk()](#Namespace+isTalk) ⇒ <code>boolean</code>
+        * [.isUser()](#Namespace+isUser) ⇒ <code>boolean</code>
+        * [.isUserTalk()](#Namespace+isUserTalk) ⇒ <code>boolean</code>
+        * [.getNormalizedText()](#Namespace+getNormalizedText) ⇒ <code>string</code>
+        * [.getCase()](#Namespace+getCase) ⇒ <code>string</code>
+    * _static_
+        * [.fromText(text, siteInfo)](#Namespace.fromText) ⇒ <code>[Namespace](#Namespace)</code> &#124; <code>undefined</code>
+        * [.main(siteInfo)](#Namespace.main) ⇒ <code>[Namespace](#Namespace)</code>
+
+<a name="new_Namespace_new"></a>
+### new Namespace(id, siteInfo)
+Represents a wiki namespace
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| id | <code>number</code> | The namespace identifier |
+| siteInfo | <code>[SiteInfo](#SiteInfo)</code> | The site metadata information. |
+
+<a name="Namespace+isSpecial"></a>
+### namespace.isSpecial() ⇒ <code>boolean</code>
+Checks whether namespace is `Special`.
+
+**Kind**: instance method of <code>[Namespace](#Namespace)</code>  
+<a name="Namespace+isMain"></a>
+### namespace.isMain() ⇒ <code>boolean</code>
+Checks whether namespace is `Main`.
+
+**Kind**: instance method of <code>[Namespace](#Namespace)</code>  
+<a name="Namespace+isTalk"></a>
+### namespace.isTalk() ⇒ <code>boolean</code>
+Checks whether namespace is `Talk`.
+
+**Kind**: instance method of <code>[Namespace](#Namespace)</code>  
+<a name="Namespace+isUser"></a>
+### namespace.isUser() ⇒ <code>boolean</code>
+Checks whether namespace is `User`.
+
+**Kind**: instance method of <code>[Namespace](#Namespace)</code>  
+<a name="Namespace+isUserTalk"></a>
+### namespace.isUserTalk() ⇒ <code>boolean</code>
+Checks whether namespace is `User_Talk`.
+
+**Kind**: instance method of <code>[Namespace](#Namespace)</code>  
+<a name="Namespace+getNormalizedText"></a>
+### namespace.getNormalizedText() ⇒ <code>string</code>
+Get the canonical name string for this namespace.
+
+**Kind**: instance method of <code>[Namespace](#Namespace)</code>  
+<a name="Namespace+getCase"></a>
+### namespace.getCase() ⇒ <code>string</code>
+Returns the case parameter for the namespace
+
+**Kind**: instance method of <code>[Namespace](#Namespace)</code>  
+<a name="Namespace.fromText"></a>
+### Namespace.fromText(text, siteInfo) ⇒ <code>[Namespace](#Namespace)</code> &#124; <code>undefined</code>
+Creates a namespace instance from namespace text or a namespace alias
+
+**Kind**: static method of <code>[Namespace](#Namespace)</code>  
+**Returns**: <code>[Namespace](#Namespace)</code> &#124; <code>undefined</code> - a namespace or undefined if it wasn't found.  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| text | <code>string</code> | Namespace name text. |
+| siteInfo | <code>[SiteInfo](#SiteInfo)</code> | the site information. |
+
+<a name="Namespace.main"></a>
+### Namespace.main(siteInfo) ⇒ <code>[Namespace](#Namespace)</code>
+Creates a namespace object for a `Main` namespace.
+
+**Kind**: static method of <code>[Namespace](#Namespace)</code>  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| siteInfo | <code>[SiteInfo](#SiteInfo)</code> | the site information. |
+
+<a name="Title"></a>
+## Title
+**Kind**: global class  
+
+* [Title](#Title)
+    * [new Title(key, namespace, siteInfo, [fragment])](#new_Title_new)
+    * _instance_
+        * [.getNormalizedText()](#Title+getNormalizedText) ⇒ <code>string</code>
+        * [.getNamespace()](#Title+getNamespace) ⇒ <code>[Namespace](#Namespace)</code>
+    * _static_
+        * [.fromPrefixedText(title, siteInfo)](#Title.fromPrefixedText) ⇒ <code>[Title](#Title)</code>
+
+<a name="new_Title_new"></a>
+### new Title(key, namespace, siteInfo, [fragment])
+Creates a new title object with article the dbKey and namespace
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| key | <code>string</code> | The article title in a form of the dbKey. |
+| namespace | <code>[Namespace](#Namespace)</code> | The article namespace. |
+| siteInfo | <code>[SiteInfo](#SiteInfo)</code> | The site metadata. |
+| [fragment] | <code>string</code> | The fragment of the title. |
+
+<a name="Title+getNormalizedText"></a>
+### title.getNormalizedText() ⇒ <code>string</code>
+Returns the normalized article title and namespace.
+
+**Kind**: instance method of <code>[Title](#Title)</code>  
+<a name="Title+getNamespace"></a>
+### title.getNamespace() ⇒ <code>[Namespace](#Namespace)</code>
+Returns the namespace of an article.
+
+**Kind**: instance method of <code>[Title](#Title)</code>  
+<a name="Title.fromPrefixedText"></a>
+### Title.fromPrefixedText(title, siteInfo) ⇒ <code>[Title](#Title)</code>
 Normalize a title according to the rules of <domain>
-  
-**Returns**: <code>string</code> - normalized version of a title.  
-**Access:** public  
+
+**Kind**: static method of <code>[Title](#Title)</code>  
+**Returns**: <code>[Title](#Title)</code> - The resulting title object.  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -36,7 +157,8 @@ Normalize a title according to the rules of <domain>
 ## SiteInfo : <code>Object</code>
 Information about a wikimedia site required to make correct
 normalization.
-  
+
+**Kind**: global typedef  
 **Properties**
 
 | Name | Type | Description |
@@ -46,6 +168,10 @@ normalization.
 | namespaces | <code>Object</code> | Site namespaces info in the same format as returned by PHP api. |
 | namespacealiases | <code>Object</code> | Site namespace aliases in the same format as returned by PHP api. |
 
+
+
+
+
 ## Usage
 
 The library returns a [Bluebird](bluebirdjs.com) promise of a normalized title. 
@@ -53,7 +179,7 @@ Wiki-specific rules are fetched from the [api](en.wikipedia.org/w/api.php), and
 cached within the `Normalizer` instance, so reusing the instance is highly recommended.
 
 ```javascript
-var result = normalizer.normalize('some_title', {
+var result = Title.fromPrefixedText('some_title', {
 	lang: 'en',
 	legaltitlechars: " %!\"$&'()*,\\-.\\/0-9:;=?@A-Z\\\\^_`a-z~\\x80-\\xFF+",
 	namespaces: {
@@ -65,6 +191,7 @@ var result = normalizer.normalize('some_title', {
 			},
 		}
 });
+console.log(result.getNormalizedText())
 ```
 
 ## Bug reporting

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ normalization.</p>
         * [.isUser()](#Namespace+isUser) ⇒ <code>boolean</code>
         * [.isUserTalk()](#Namespace+isUserTalk) ⇒ <code>boolean</code>
         * [.getNormalizedText()](#Namespace+getNormalizedText) ⇒ <code>string</code>
-        * [.getCase()](#Namespace+getCase) ⇒ <code>string</code>
     * _static_
         * [.fromText(text, siteInfo)](#Namespace.fromText) ⇒ <code>[Namespace](#Namespace)</code> &#124; <code>undefined</code>
         * [.main(siteInfo)](#Namespace.main) ⇒ <code>[Namespace](#Namespace)</code>
@@ -80,11 +79,6 @@ Checks whether namespace is `User_Talk`.
 Get the canonical name string for this namespace.
 
 **Kind**: instance method of <code>[Namespace](#Namespace)</code>  
-<a name="Namespace+getCase"></a>
-### namespace.getCase() ⇒ <code>string</code>
-Returns the case parameter for the namespace
-
-**Kind**: instance method of <code>[Namespace](#Namespace)</code>  
 <a name="Namespace.fromText"></a>
 ### Namespace.fromText(text, siteInfo) ⇒ <code>[Namespace](#Namespace)</code> &#124; <code>undefined</code>
 Creates a namespace instance from namespace text or a namespace alias
@@ -117,7 +111,7 @@ Creates a namespace object for a `Main` namespace.
         * [.getPrefixedDBKey()](#Title+getPrefixedDBKey) ⇒ <code>string</code>
         * [.getNamespace()](#Title+getNamespace) ⇒ <code>[Namespace](#Namespace)</code>
     * _static_
-        * [.fromPrefixedText(title, siteInfo)](#Title.fromPrefixedText) ⇒ <code>[Title](#Title)</code>
+        * [.newFromText(title, siteInfo)](#Title.newFromText) ⇒ <code>[Title](#Title)</code>
 
 <a name="new_Title_new"></a>
 ### new Title(key, namespace, siteInfo, [fragment])
@@ -127,7 +121,7 @@ Creates a new title object with article the dbKey and namespace
 | Param | Type | Description |
 | --- | --- | --- |
 | key | <code>string</code> | The article title in a form of the dbKey. |
-| namespace | <code>[Namespace](#Namespace)</code> | The article namespace. |
+| namespace | <code>[Namespace](#Namespace)</code> &#124; <code>number</code> | The article namespace. |
 | siteInfo | <code>[SiteInfo](#SiteInfo)</code> | The site metadata. |
 | [fragment] | <code>string</code> | The fragment of the title. |
 
@@ -141,8 +135,8 @@ Returns the normalized article title and namespace.
 Returns the namespace of an article.
 
 **Kind**: instance method of <code>[Title](#Title)</code>  
-<a name="Title.fromPrefixedText"></a>
-### Title.fromPrefixedText(title, siteInfo) ⇒ <code>[Title](#Title)</code>
+<a name="Title.newFromText"></a>
+### Title.newFromText(title, siteInfo) ⇒ <code>[Title](#Title)</code>
 Normalize a title according to the rules of <domain>
 
 **Kind**: static method of <code>[Title](#Title)</code>  
@@ -165,12 +159,9 @@ normalization.
 | --- | --- | --- |
 | lang | <code>string</code> | Site language code. |
 | legaltitlechars | <code>string</code> | A perl-like regex for characters allowed in the page title. |
+| case | <code>string</code> | Whether to capitalize the first letter of the title. Could be obtained from the `general` section of the `siteInfo` php API response. |
 | namespaces | <code>Object</code> | Site namespaces info in the same format as returned by PHP api. |
 | namespacealiases | <code>Object</code> | Site namespace aliases in the same format as returned by PHP api. |
-
-
-
-
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Creates a namespace object for a `Main` namespace.
 * [Title](#Title)
     * [new Title(key, namespace, siteInfo, [fragment])](#new_Title_new)
     * _instance_
-        * [.getNormalizedText()](#Title+getNormalizedText) ⇒ <code>string</code>
+        * [.getPrefixedDBKey()](#Title+getPrefixedDBKey) ⇒ <code>string</code>
         * [.getNamespace()](#Title+getNamespace) ⇒ <code>[Namespace](#Namespace)</code>
     * _static_
         * [.fromPrefixedText(title, siteInfo)](#Title.fromPrefixedText) ⇒ <code>[Title](#Title)</code>
@@ -131,8 +131,8 @@ Creates a new title object with article the dbKey and namespace
 | siteInfo | <code>[SiteInfo](#SiteInfo)</code> | The site metadata. |
 | [fragment] | <code>string</code> | The fragment of the title. |
 
-<a name="Title+getNormalizedText"></a>
-### title.getNormalizedText() ⇒ <code>string</code>
+<a name="Title+getPrefixedDBKey"></a>
+### title.getPrefixedDBKey() ⇒ <code>string</code>
 Returns the normalized article title and namespace.
 
 **Kind**: instance method of <code>[Title](#Title)</code>  
@@ -191,7 +191,7 @@ var result = Title.fromPrefixedText('some_title', {
 			},
 		}
 });
-console.log(result.getNormalizedText())
+console.log(result.getPrefixedDBKey());
 ```
 
 ## Bug reporting

--- a/lib/index.js
+++ b/lib/index.js
@@ -289,7 +289,7 @@ function Title(key, namespace, siteInfo, fragment) {
  *
  * @returns {Title} The resulting title object.
  */
-Title.fromPrefixedText = function(title, siteInfo) {
+Title.newFromText = function(title, siteInfo) {
     if (typeof title !== 'string') {
         throw new TypeError('Invalid type of title parameter. Must be a string');
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,12 +3,6 @@
 var sanitizeIP = require('./ip');
 var utils      = require('./utils');
 
-var NS_SPECIAL = '-1';
-var NS_MAIN = '0';
-var NS_TALK = '1';
-var NS_USER = '2';
-var NS_USER_TALK = '3';
-
 // Polyfill for array.find for node 0.10 support.
 function arrayFind(array, predicate) {
     for (var i = 0; i < array.length; i++) {
@@ -34,6 +28,127 @@ function arrayFind(array, predicate) {
  *                                     as returned by PHP api.
  */
 
+/**
+ * Represents a wiki namespace
+ *
+ * @param {number} id The namespace identifier
+ * @param {SiteInfo} siteInfo The site metadata information.
+ * @constructor
+ */
+function Namespace(id, siteInfo) {
+    this._siteInfo = siteInfo;
+    this._id = Number(id);
+}
+
+function _getNSIndex(nsName, siteInfo) {
+    function canonicalName(name) {
+        return name.toUpperCase().replace(/_/g, ' ');
+    }
+    var name = canonicalName(nsName);
+    var index = arrayFind(Object.keys(siteInfo.namespaces), function(nsId) {
+        var ns = siteInfo.namespaces[nsId];
+        return ns.canonical && canonicalName(ns.canonical) === name
+        || ns['*'] && canonicalName(ns['*']) === name;
+    });
+    if (!index) {
+        // Not found within canonical names, try aliases
+        index = arrayFind(siteInfo.namespacealiases, function(alias) {
+            return name === canonicalName(alias['*']);
+        });
+        if (index !== undefined) {
+            index = '' + index.id;
+        }
+    }
+    return index;
+}
+
+/**
+ * Creates a namespace instance from namespace text or a namespace alias
+ *
+ * @param {string} text Namespace name text.
+ * @param {SiteInfo} siteInfo the site information.
+ * @returns {Namespace|undefined} a namespace or undefined if it wasn't found.
+ */
+Namespace.fromText = function(text, siteInfo) {
+    var index = _getNSIndex(text, siteInfo);
+    if (index !== undefined) {
+        return new Namespace(index, siteInfo);
+    }
+    return undefined;
+};
+
+/**
+ * Creates a namespace object for a `Main` namespace.
+ *
+ * @param {SiteInfo} siteInfo the site information.
+ * @returns {Namespace}
+ */
+Namespace.main = function(siteInfo) {
+    return new Namespace(0, siteInfo);
+};
+
+/**
+ * Checks whether namespace is `Special`.
+ *
+ * @returns {boolean}
+ */
+Namespace.prototype.isSpecial = function() {
+    return this._id === -1;
+};
+
+/**
+ * Checks whether namespace is `Main`.
+ *
+ * @returns {boolean}
+ */
+Namespace.prototype.isMain = function() {
+    return this._id === 0;
+};
+
+/**
+ * Checks whether namespace is `Talk`.
+ *
+ * @returns {boolean}
+ */
+Namespace.prototype.isTalk = function() {
+    return this._id === 1;
+};
+
+/**
+ * Checks whether namespace is `User`.
+ *
+ * @returns {boolean}
+ */
+Namespace.prototype.isUser = function() {
+    return this._id === 2;
+};
+
+/**
+ * Checks whether namespace is `User_Talk`.
+ *
+ * @returns {boolean}
+ */
+Namespace.prototype.isUserTalk = function() {
+    return this._id === 3;
+};
+
+/**
+ * Get the canonical name string for this namespace.
+ *
+ * @returns {string}
+ */
+Namespace.prototype.getNormalizedText = function() {
+    return this._siteInfo.namespaces[this._id + '']['*'].replace(/ /g, '_');
+};
+
+/**
+ * Returns the case parameter for the namespace
+ *
+ * @returns {string}
+ */
+Namespace.prototype.getCase = function() {
+    return this._siteInfo.namespaces[this._id + ''].case;
+};
 
 var regexCache = {};
 function _createInvalidTitleRegex(legalTitleChars) {
@@ -53,30 +168,8 @@ function _createInvalidTitleRegex(legalTitleChars) {
     return regexCache[legalTitleChars];
 }
 
-function _getNSIndex(nsName, siteInfo) {
-    function canonicalName(name) {
-        return name.toUpperCase().replace(/_/g, ' ');
-    }
-    var name = canonicalName(nsName);
-    var index = arrayFind(Object.keys(siteInfo.namespaces), function(nsId) {
-        var ns = siteInfo.namespaces[nsId];
-        return ns.canonical && canonicalName(ns.canonical) === name
-                || ns['*'] && canonicalName(ns['*']) === name;
-    });
-    if (!index) {
-        // Not found within canonical names, try aliases
-        index = arrayFind(siteInfo.namespacealiases, function(alias) {
-            return name === canonicalName(alias['*']);
-        });
-        if (index !== undefined) {
-            index = '' + index.id;
-        }
-    }
-    return index;
-}
-
 function _capitalizeTitle(result, siteInfo) {
-    if (siteInfo.namespaces[result.namespace].case === 'first-letter') {
+    if (result.namespace.getCase() === 'first-letter') {
         if (result.title[0] === 'i' && (siteInfo.lang === 'az'
                 || siteInfo.lang === 'tr'
                 || siteInfo.lang === 'kaa'
@@ -95,7 +188,7 @@ function _splitNamespace(title, siteInfo) {
     var match = title.match(prefixRegex);
     if (match) {
         var namespaceText = match[1];
-        var ns = _getNSIndex(namespaceText, siteInfo);
+        var ns = Namespace.fromText(namespaceText, siteInfo);
         if (ns !== undefined) {
             return {
                 title: match[2],
@@ -105,7 +198,7 @@ function _splitNamespace(title, siteInfo) {
     }
     return {
         title: title,
-        namespace: NS_MAIN
+        namespace: Namespace.main(siteInfo)
     };
 }
 
@@ -152,7 +245,7 @@ function _checkRelativeTitle(title) {
 // Disallow Talk:File:x type titles.
 function _checkTalkNamespace(title, siteInfo) {
     var split = _splitNamespace(title, siteInfo);
-    if (split.namespace && split.namespace !== NS_MAIN) {
+    if (split.namespace && !split.namespace.isMain()) {
         throw new utils.TitleError({
             type: 'title-invalid-talk-namespace',
             title: title
@@ -161,7 +254,7 @@ function _checkTalkNamespace(title, siteInfo) {
 }
 
 function _checkMaxLength(title, namespace) {
-    var maxLength = namespace !== NS_SPECIAL ? 255 : 512;
+    var maxLength = !namespace.isSpecial() ? 255 : 512;
     if (title.length > maxLength) {
         throw new utils.TitleError({
             type: 'title-invalid-too-long',
@@ -172,16 +265,30 @@ function _checkMaxLength(title, namespace) {
 }
 
 /**
+ * Creates a new title object with article the dbKey and namespace
+ *
+ * @param {string} key The article title in a form of the dbKey.
+ * @param {Namespace} namespace The article namespace.
+ * @param {SiteInfo} siteInfo The site metadata.
+ * @param {string} [fragment] The fragment of the title.
+ * @constructor
+ */
+function Title(key, namespace, siteInfo, fragment) {
+    this._key = key;
+    this._namespace = namespace;
+    this._siteInfo = siteInfo;
+    this._fragment = fragment;
+}
+
+/**
  * Normalize a title according to the rules of <domain>
  *
  * @param {string} title The page title to normalize.
  * @param {SiteInfo} siteInfo The site information.
  *
- * @returns {string} normalized version of a title.
- *
- * @public
+ * @returns {Title} The resulting title object.
  */
-function normalize(title, siteInfo) {
+Title.fromPrefixedText = function(title, siteInfo) {
     if (typeof title !== 'string') {
         throw new TypeError('Invalid type of title parameter. Must be a string');
     }
@@ -206,7 +313,7 @@ function normalize(title, siteInfo) {
     _checkEmptyTitle(title);
 
     var result = _splitNamespace(title, siteInfo);
-    if (result.namespace === NS_TALK) {
+    if (result.namespace.isTalk()) {
         _checkTalkNamespace(result.title, siteInfo);
     }
     var fragmentIndex = result.title.indexOf('#');
@@ -231,28 +338,43 @@ function normalize(title, siteInfo) {
 
     result = _capitalizeTitle(result, siteInfo);
 
-    if (result.namespace !== NS_MAIN) {
+    if (!result.namespace.isMain()) {
         _checkEmptyTitle(result.title);
     }
 
-    if (result.namespace === NS_USER || result.namespace === NS_USER_TALK) {
+    if (result.namespace.isUser() || result.namespace.isUserTalk()) {
         result.title = sanitizeIP(result.title);
     }
 
-    var normalized = result.title;
-
-    if (result.namespace !== NS_MAIN) {
-        normalized = siteInfo.namespaces[result.namespace]['*'].replace(/ /g, '_')
-            + ':' + normalized;
-    }
-
-    if (result.fragment) {
-        normalized = normalized + '#' + result.fragment;
-    }
-
-    return normalized;
-}
-
-module.exports = {
-    normalize: normalize
+    return new Title(result.title, result.namespace, siteInfo);
 };
+
+/**
+ * Returns the normalized article title and namespace.
+ *
+ * @returns {string}
+ */
+Title.prototype.getNormalizedText = function() {
+    var normalized = this._key;
+    if (!this._namespace.isMain()) {
+        normalized = this._namespace.getNormalizedText() + ':' + normalized;
+    }
+
+    if (this._fragment) {
+        normalized = normalized + '#' + this._fragment;
+    }
+    return normalized;
+};
+
+/**
+ * Returns the namespace of an article.
+ *
+ * @returns {Namespace}
+ */
+Title.prototype.getNamespace = function() {
+    return this._namespace;
+};
+
+module.exports = {};
+module.exports.Namespace = Namespace;
+module.exports.Title = Title;

--- a/lib/index.js
+++ b/lib/index.js
@@ -268,14 +268,15 @@ function _checkMaxLength(title, namespace) {
  * Creates a new title object with article the dbKey and namespace
  *
  * @param {string} key The article title in a form of the dbKey.
- * @param {Namespace} namespace The article namespace.
+ * @param {Namespace|number} namespace The article namespace.
  * @param {SiteInfo} siteInfo The site metadata.
  * @param {string} [fragment] The fragment of the title.
  * @constructor
  */
 function Title(key, namespace, siteInfo, fragment) {
     this._key = key;
-    this._namespace = namespace;
+    this._namespace = namespace.constructor.name === 'Namespace' ?
+            namespace : new Namespace(namespace, siteInfo);
     this._siteInfo = siteInfo;
     this._fragment = fragment;
 }
@@ -354,7 +355,7 @@ Title.fromPrefixedText = function(title, siteInfo) {
  *
  * @returns {string}
  */
-Title.prototype.getNormalizedText = function() {
+Title.prototype.getPrefixedDBKey = function() {
     var normalized = this._key;
     if (!this._namespace.isMain()) {
         normalized = this._namespace.getNormalizedText() + ':' + normalized;

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,11 +21,13 @@ function arrayFind(array, predicate) {
  * @type Object
  * @property {string} lang Site language code.
  * @property {string} legaltitlechars A perl-like regex for characters
- *                                    allowed in the page title.
+ * allowed in the page title.
+ * @property {string} case Whether to capitalize the first letter of the title.
+ * Could be obtained from the `general` section of the `siteInfo` php API response.
  * @property {Object} namespaces Site namespaces info in the same format as
- *                               returned by PHP api.
+ * returned by PHP api.
  * @property {Object} namespacealiases Site namespace aliases in the same format
- *                                     as returned by PHP api.
+ * as returned by PHP api.
  */
 
 /**
@@ -141,15 +143,6 @@ Namespace.prototype.getNormalizedText = function() {
     return this._siteInfo.namespaces[this._id + '']['*'].replace(/ /g, '_');
 };
 
-/**
- * Returns the case parameter for the namespace
- *
- * @returns {string}
- */
-Namespace.prototype.getCase = function() {
-    return this._siteInfo.namespaces[this._id + ''].case;
-};
-
 var regexCache = {};
 function _createInvalidTitleRegex(legalTitleChars) {
     if (regexCache[legalTitleChars]) {
@@ -169,7 +162,7 @@ function _createInvalidTitleRegex(legalTitleChars) {
 }
 
 function _capitalizeTitle(result, siteInfo) {
-    if (result.namespace.getCase() === 'first-letter') {
+    if (siteInfo.case === 'first-letter') {
         if (result.title[0] === 'i' && (siteInfo.lang === 'az'
                 || siteInfo.lang === 'tr'
                 || siteInfo.lang === 'kaa'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mediawiki-title",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Title normalization library for mediawiki",
   "main": "lib/index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -194,7 +194,7 @@ describe('Normalization', function() {
         it('For ' + test[0] + ' should normalize ' + test[1] + ' to ' + test[2], function() {
             return getSiteInfo(test[0])
             .then(function(siteInfo) {
-                return Title.fromPrefixedText(test[1], siteInfo).getNormalizedText();
+                return Title.fromPrefixedText(test[1], siteInfo).getPrefixedDBKey();
             })
             .then(function(res) {
                 assert.deepEqual(res, test[2]);
@@ -293,7 +293,7 @@ describe('Utilities', function () {
                             return Title.fromPrefixedText('1', siteInfo);
                         })
                         .then(function (res) {
-                            assert.deepEqual(res.getNormalizedText(), '1');
+                            assert.deepEqual(res.getPrefixedDBKey(), '1');
                         });
                     });
                 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var assert = require('assert');
-var normalize = require('../lib/index').normalize;
+var Title = require('../lib/index').Title;
 var utils = require('../lib/utils');
 var preq = require('preq');
 
@@ -92,7 +92,7 @@ describe('Validation', function () {
         it('should throw ' + testCase[1] + ' error for ' + name, function() {
             return getSiteInfo('en.wikipedia.org')
             .then(function(siteInfo) {
-                return normalize(testCase[0], siteInfo);
+                return Title.fromPrefixedText(testCase[0], siteInfo);
             })
             .then(function () {
                 throw new Error('Error should be thrown');
@@ -139,7 +139,7 @@ describe('Validation', function () {
         it(name + ' should be valid', function() {
             return getSiteInfo('en.wikipedia.org')
             .then(function(siteInfo) {
-                return normalize(title[0], siteInfo);
+                return Title.fromPrefixedText(title[0], siteInfo);
             })
         });
     });
@@ -194,7 +194,7 @@ describe('Normalization', function() {
         it('For ' + test[0] + ' should normalize ' + test[1] + ' to ' + test[2], function() {
             return getSiteInfo(test[0])
             .then(function(siteInfo) {
-                return normalize(test[1], siteInfo);
+                return Title.fromPrefixedText(test[1], siteInfo).getNormalizedText();
             })
             .then(function(res) {
                 assert.deepEqual(res, test[2]);
@@ -290,10 +290,10 @@ describe('Utilities', function () {
                     it('Should work for ' + domain, function() {
                         return getSiteInfo(domain)
                         .then(function(siteInfo) {
-                            return normalize('1', siteInfo);
+                            return Title.fromPrefixedText('1', siteInfo);
                         })
                         .then(function (res) {
-                            assert.deepEqual(res, '1');
+                            assert.deepEqual(res.getNormalizedText(), '1');
                         });
                     });
                 });

--- a/test/index.js
+++ b/test/index.js
@@ -29,6 +29,7 @@ var getSiteInfo = function(domain) {
         return {
             lang: res.body.query.general.lang,
             legaltitlechars: res.body.query.general.legaltitlechars,
+            case: res.body.query.general.case,
             namespaces: res.body.query.namespaces,
             namespacealiases: res.body.query.namespacealiases
         }
@@ -185,7 +186,6 @@ describe('Normalization', function() {
         [ 'en.wikipedia.org', 'User_talk:::1', 'User_talk:0:0:0:0:0:0:0:1'],
         [ 'en.wikipedia.org', 'User_talk:::1/24', 'User_talk:0:0:0:0:0:0:0:1/24'],
         // Case-sensitive namespace
-        [ 'en.wikipedia.org', 'Gadget definition:test', 'Gadget_definition:test'],
         [ 'en.wikipedia.org', 'user:pchelolo', 'User:Pchelolo'],
 
     ];

--- a/test/index.js
+++ b/test/index.js
@@ -92,7 +92,7 @@ describe('Validation', function () {
         it('should throw ' + testCase[1] + ' error for ' + name, function() {
             return getSiteInfo('en.wikipedia.org')
             .then(function(siteInfo) {
-                return Title.fromPrefixedText(testCase[0], siteInfo);
+                return Title.newFromText(testCase[0], siteInfo);
             })
             .then(function () {
                 throw new Error('Error should be thrown');
@@ -139,7 +139,7 @@ describe('Validation', function () {
         it(name + ' should be valid', function() {
             return getSiteInfo('en.wikipedia.org')
             .then(function(siteInfo) {
-                return Title.fromPrefixedText(title[0], siteInfo);
+                return Title.newFromText(title[0], siteInfo);
             })
         });
     });
@@ -194,7 +194,7 @@ describe('Normalization', function() {
         it('For ' + test[0] + ' should normalize ' + test[1] + ' to ' + test[2], function() {
             return getSiteInfo(test[0])
             .then(function(siteInfo) {
-                return Title.fromPrefixedText(test[1], siteInfo).getPrefixedDBKey();
+                return Title.newFromText(test[1], siteInfo).getPrefixedDBKey();
             })
             .then(function(res) {
                 assert.deepEqual(res, test[2]);
@@ -290,7 +290,7 @@ describe('Utilities', function () {
                     it('Should work for ' + domain, function() {
                         return getSiteInfo(domain)
                         .then(function(siteInfo) {
-                            return Title.fromPrefixedText('1', siteInfo);
+                            return Title.newFromText('1', siteInfo);
                         })
                         .then(function (res) {
                             assert.deepEqual(res.getPrefixedDBKey(), '1');


### PR DESCRIPTION
Clients need to be able to find out the namespace index for the page namespace, so return it together with the normalised title.

cc @wikimedia/services 
Bug: https://phabricator.wikimedia.org/T129135
