### PR TITLE
Don't include the fragment

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -353,11 +353,16 @@ Title.prototype.getPrefixedDBKey = function() {
     if (!this._namespace.isMain()) {
         normalized = this._namespace.getNormalizedText() + ':' + normalized;
     }
-
-    if (this._fragment) {
-        normalized = normalized + '#' + this._fragment.replace(/ /g, '_');
-    }
     return normalized;
+};
+
+/**
+ * Returns the normalized fragment part of the original title
+ *
+ * @returns {string|undefined}
+ */
+Title.prototype.getFragment = function() {
+    return this._fragment;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mediawiki-title",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Title normalization library for mediawiki",
   "main": "lib/index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -189,7 +189,7 @@ describe('Normalization', function() {
         [ 'en.wikipedia.org', 'user:pchelolo', 'User:Pchelolo'],
         [ 'en.wikipedia.org',
             'list of Neighbours characters (2016)#Tom Quill',
-            'List_of_Neighbours_characters_(2016)#Tom_Quill']
+            'List_of_Neighbours_characters_(2016)']
 
     ];
 
@@ -204,6 +204,16 @@ describe('Normalization', function() {
             });
         });
     });
+
+    it('Should normalize fragment', function() {
+        return getSiteInfo('en.wikipedia.org')
+        .then(function(siteInfo) {
+            return Title.newFromText('Test#some fragment', siteInfo);
+        })
+        .then(function(res) {
+            assert.deepEqual(res.getFragment(), 'some_fragment');
+        });
+    })
 });
 
 describe('Utilities', function () {


### PR DESCRIPTION
Some more thinking made me reconsider. We don't need to include a fragment in the normalised title, as the primary user of the library is RESTBase and Parsoid, and those fragments mean nothing for them. So, we need ti strip out the fragment as nobody should actually send them. Also fragment stripping doesn't work in varnish for us -> one more reason to strip them.

cc @wikimedia/services 