### PR TITLE
Define is* style namespace helpers for all namespaces in core

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,50 +89,38 @@ Namespace.main = function(siteInfo) {
     return new Namespace(0, siteInfo);
 };
 
-/**
- * Checks whether namespace is `Special`.
- *
- * @returns {boolean}
- */
-Namespace.prototype.isSpecial = function() {
-    return this._id === -1;
+/* Namespace id definitions from Defines.php in mediawiki-core */
+var nameSpaceIds = {
+    Media: -2,
+    Special: -1,
+    Main: 0,
+    Talk: 1,
+    User: 2,
+    UserTalk: 3,
+    Project: 4,
+    ProjectTalk: 5,
+    File: 6,
+    FileTalk: 7,
+    Mediawiki: 8,
+    MediawikiTalk: 9,
+    Template: 10,
+    TemplateTalk: 11,
+    Help: 12,
+    HelpTalk: 13,
+    Category: 14,
+    CategoryTalk: 15,
 };
+nameSpaceIds.Image = nameSpaceIds.File;
+nameSpaceIds.ImageTalk = nameSpaceIds.FileTalk;
 
-/**
- * Checks whether namespace is `Main`.
- *
- * @returns {boolean}
- */
-Namespace.prototype.isMain = function() {
-    return this._id === 0;
-};
-
-/**
- * Checks whether namespace is `Talk`.
- *
- * @returns {boolean}
- */
-Namespace.prototype.isTalk = function() {
-    return this._id === 1;
-};
-
-/**
- * Checks whether namespace is `User`.
- *
- * @returns {boolean}
- */
-Namespace.prototype.isUser = function() {
-    return this._id === 2;
-};
-
-/**
- * Checks whether namespace is `User_Talk`.
- *
- * @returns {boolean}
- */
-Namespace.prototype.isUserTalk = function() {
-    return this._id === 3;
-};
+/* Define a boolean is<ns> function for every namespace */
+for (var ns in nameSpaceIds) {
+    (function(id) {
+        Namespace.prototype['is' + ns] = function() {
+            return this._id === id;
+        };
+    })(nameSpaceIds[ns]);
+}
 
 /**
  * Get the canonical name string for this namespace.


### PR DESCRIPTION
* Parsoid uses isFile and isCategory. We / others may find a use
  for the other namespaces later.