### PR TITLE
Prohibit UTF-8 replacement character explicitly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,16 @@
 var sanitizeIP = require('./ip');
 var utils      = require('./utils');
 
+/**
+ * A UTF-8 replacement character that's explicitly prohibited in the title
+ *
+ * @type {string}
+ * @const
+ */
+// We're using String.fromCharCode because the symbol itself is not liked by JSCS
+// and String.fromCodePoint() is around only starting from ES6
+var UTF_8_REPLACEMENT = String.fromCharCode(0xFFFD);
+
 // Polyfill for array.find for node 0.10 support.
 function arrayFind(array, predicate) {
     for (var i = 0; i < array.length; i++) {
@@ -12,6 +22,8 @@ function arrayFind(array, predicate) {
     }
     return undefined;
 }
+
+
 
 /**
  * Information about a wikimedia site required to make correct
@@ -299,6 +311,13 @@ Title.newFromText = function(title, siteInfo) {
     .replace(/[ \xA0\u1680\u180E\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]+/g, '_')
     // Trim _ from beginning and end
     .replace(/(?:^_+)|(?:_+$)/g, '');
+
+    if (title.indexOf(UTF_8_REPLACEMENT) !== -1) {
+        throw new utils.TitleError({
+            type: 'title-invalid-utf8',
+            title: title
+        });
+    }
 
     // Initial colon indicates main namespace rather than specified default
     // but should not create invalid {ns,title} pairs such as {0,Project:Foo}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mediawiki-title",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Title normalization library for mediawiki",
   "main": "lib/index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -32,7 +32,9 @@ var getSiteInfo = function(domain) {
 };
 
 describe('Validation', function () {
-    var invalidTitles = [['', 'title-invalid-empty'],
+    var invalidTitles = [
+        ['foo�|bar', 'title-invalid-characters'],
+        ['', 'title-invalid-empty'],
         [':', 'title-invalid-empty'],
         ['__  __', 'title-invalid-empty'],
         ['  __  ', 'title-invalid-empty'],

--- a/test/index.js
+++ b/test/index.js
@@ -33,7 +33,7 @@ var getSiteInfo = function(domain) {
 
 describe('Validation', function () {
     var invalidTitles = [
-        ['foo�|bar', 'title-invalid-characters'],
+        ['foo�', 'title-invalid-utf8'],
         ['', 'title-invalid-empty'],
         [':', 'title-invalid-empty'],
         ['__  __', 'title-invalid-empty'],


### PR DESCRIPTION
MW explicitly prohibits the unicode replacement characters in all titles [here].(https://github.com/wikimedia/mediawiki/blob/358f20218c36bc77f10dbea81ad43454762ace8a/includes/title/MediaWikiTitleCodec.php#L249-L252) I've missed that somehow then ported the code, so fixing an issue now.