### PR TITLE
Expose canonical namespace name too

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -141,7 +141,7 @@ for (var ns in nameSpaceIds) {
 }
 
 /**
- * Get the canonical name string for this namespace.
+ * Get the normalized localized name string for this namespace.
  *
  * @returns {string}
  */
@@ -149,6 +149,15 @@ Namespace.prototype.getNormalizedText = function() {
     var nsInfo = this._siteInfo.namespaces[this._id + ''];
     var nsName = nsInfo['*'] || nsInfo.name;
     return nsName.replace(/ /g, '_');
+};
+
+/**
+ * Get the canonical non-localized name string for this namespace.
+ *
+ * @returns {string}
+ */
+Namespace.prototype.getCanonicalText = function() {
+    return this._siteInfo.namespaces[this._id + ''].canonical.replace(/ /g, '_');
 };
 
 /**


### PR DESCRIPTION
For 'redirect to commons' feature in RESTBase we need to expose the canonical name of the namespace

cc @wikimedia/services 