### PR TITLE
Namespace: Add method to identify talk namespaces

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -140,6 +140,11 @@ for (var ns in nameSpaceIds) {
     })(nameSpaceIds[ns]);
 }
 
+Namespace.prototype.isATalkNamespace = function() {
+	// See https://www.mediawiki.org/wiki/Manual:Namespace#Subject_and_talk_namespaces
+	return this._id % 2 === 1;
+};
+
 /**
  * Get the normalized localized name string for this namespace.
  *


### PR DESCRIPTION
Required for Parsoid functionality in https://gerrit.wikimedia.org/r/#/c/295445/5/lib/wt2html/tt/LinkHandler.js