### PR TITLE
Improve the max-length criteria

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -279,7 +279,7 @@ function _checkTalkNamespace(title, siteInfo) {
 }
 
 function _checkMaxLength(title, namespace) {
-    var maxLength = !namespace.isSpecial() ? 255 : 512;
+    var maxLength = namespace.isSpecial() ? 512 : 256;
     if (title.length > maxLength) {
         throw new utils.TitleError({
             type: 'title-invalid-too-long',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mediawiki-title",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Title normalization library for mediawiki",
   "main": "lib/index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -74,7 +74,7 @@ function doTest(formatversion) {
             ['A ~~~~ Signature', 'title-invalid-magic-tilde'],
             ['A ~~~~~ Timestamp', 'title-invalid-magic-tilde'],
             // Length
-            [ new Array(257).join('x'), 'title-invalid-too-long' ],
+            [ new Array(258).join('x'), 'title-invalid-too-long' ],
             [ 'Special:' + new Array(514).join('x'), 'title-invalid-too-long' ],
             // Namespace prefix without actual title
             ['Talk:', 'title-invalid-empty'],
@@ -124,6 +124,7 @@ function doTest(formatversion) {
             // Special pages can have longer titles
             [ 'Special:' + new Array(500).join('x') ],
             [ new Array(252).join('x') ],
+            [ new Array(257).join('x') ],
             [ '-' ],
             [ 'aũ' ],
             [ '"Believing_Women"_in_Islam._Unreading_Patriarchal_Interpretations_of_the_Qur\\\'ān']


### PR DESCRIPTION
Mediawiki considers any titles that are >= 257 symbols [invalid](https://en.wikipedia.org/wiki/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa), while a title with 256 symbols is [valid](https://en.wikipedia.org/wiki/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa).

Although MW tells on the error message that title with 256 symbols should be invalid, it's easier to update mediawiki-title to match MW behaviour.

cc @wikimedia/services @subbuss 