### PR TITLE
Add Title.getPrefixedText method to get readable title text

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,19 @@ function arrayFind(array, predicate) {
 }
 
 
+/**
+ * Convert db-key to readable text.
+ *
+ * @param {string} s
+ * @return {string}
+ */
+function text(s) {
+    if (s !== null && s !== undefined) {
+        return s.replace(/_/g, ' ');
+    } else {
+        return '';
+    }
+}
 
 /**
  * Information about a wikimedia site required to make correct
@@ -435,6 +448,17 @@ Title.prototype.getPrefixedDBKey = function() {
         normalized = this._namespace.getNormalizedText() + ':' + normalized;
     }
     return normalized;
+};
+
+/**
+ * Get the full page name (transformed by #text)
+ *
+ * Example: "File:Example image.svg" for "File:Example_image.svg".
+ *
+ * @return {string}
+ */
+Title.prototype.getPrefixedText = function() {
+    return text(this.getPrefixedDBKey());
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -279,6 +279,16 @@ function doTest(formatversion) {
                 assert.deepEqual(res.getFragment(), 'some_fragment');
             });
         });
+
+        it('Should normalize and give readable title', function() {
+            return getSiteInfo('en.wikipedia.org')
+            .then(function(siteInfo) {
+                return Title.newFromText('X-Men_(film_series)', siteInfo);
+            })
+            .then(function(res) {
+                assert.deepEqual(res.getPrefixedText(), 'X-Men (film series)');
+            });
+        });
     });
 
     describe('Defaults', function() {


### PR DESCRIPTION
This is copy of getPrefixedText method that exist in mediawiki core
mediawiki.Title.js#getPrefixedText

Testcase included.