### PR TITLE
Revert "Strip additional special Unicode characters from title (#46)"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -409,10 +409,8 @@ class Title {
         }
 
         title = title
-        // Strip soft hyphens (U+00AD) and Unicode directional formatting
-        // characters (U+061C, U+200E, U+200F, U+202A. U+202B, U+202C, U+202D,
-        // U+202E, U+2066, U+2067, U+2068, U+2069).
-        .replace(/[\u00AD\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]+/g, '')
+        // Strip Unicode bidi override characters.
+        .replace(/[\u200E\u200F\u202A-\u202E]/g, '')
         // Clean up whitespace
         .replace(/[ _\u00A0\u1680\u180E\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]+/g, '_')
         // Trim _ from beginning and end

--- a/test/index.js
+++ b/test/index.js
@@ -172,7 +172,6 @@ const doTest = (formatversion) => {
             // eslint-disable-next-line max-len
             ['en.wikipedia.org', 'Foo \u00A0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u2028\u2029\u202F\u205F\u3000 bar', 'Foo_bar'],
             ['en.wikipedia.org', 'Foo\u200E\u200F\u202A\u202B\u202C\u202D\u202Ebar', 'Foobar'],
-            ['en.wikipedia.org', 'Foo\u00AD\u061C\u2066\u2067\u2068\u2069bar', 'Foobar'],
             // Special handling for `i` first character
             ['tr.wikipedia.org', 'iTestTest', 'İTestTest'],
             ['az.wikipedia.org', 'iTestTest', 'İTestTest'],


### PR DESCRIPTION
This reverts commit eef872ac3c834b2e3ea065ca4287fff535812c15.

The corresponding core patch was reverted in
https://gerrit.wikimedia.org/r/c/mediawiki/core/+/436598

This reverts #46 and should fix the issue in https://phabricator.wikimedia.org/T284734

/cc @cscott @jdforrester @Pchelolo @subbuss 